### PR TITLE
Update InventoryPatches.cs

### DIFF
--- a/CraftyBoxes/Patches/InventoryPatches.cs
+++ b/CraftyBoxes/Patches/InventoryPatches.cs
@@ -62,7 +62,7 @@ static class InventoryGuiOnCraftPressedPatch
     static bool Prefix(InventoryGui __instance, KeyValuePair<Recipe, ItemDrop.ItemData> ___m_selectedRecipe,
         ItemDrop.ItemData ___m_craftUpgradeItem)
     {
-        if (!CraftyBoxesPlugin.modEnabled.Value || !CraftyBoxesPlugin.AllowByKey() ||
+        if (!CraftyBoxesPlugin.modEnabled.Value || 
             !CraftyBoxesPlugin.pullItemsKey.Value.IsPressed() || ___m_selectedRecipe.Key == null)
             return true;
 


### PR DESCRIPTION
Allow to pull items even when SwitchPrevent is activated. This will enable the pulling feature when you have to toggle SwitchPrevent in the config because of the epic item pickup lag in combination with AzuAutoStore.